### PR TITLE
Fix for #62

### DIFF
--- a/lib/Service/VerdictService.php
+++ b/lib/Service/VerdictService.php
@@ -141,6 +141,7 @@ class VerdictService {
 	 */
     public static function isFileTooLargeToScan(string $path): bool {
         $size = filesize($path);
+        if ($size === 0) { return false; }
         return !$size || $size > self::MAX_FILE_SIZE;
     }
 

--- a/lib/Service/VerdictService.php
+++ b/lib/Service/VerdictService.php
@@ -141,8 +141,7 @@ class VerdictService {
 	 */
     public static function isFileTooLargeToScan(string $path): bool {
         $size = filesize($path);
-        if ($size === 0) { return false; }
-        return !$size || $size > self::MAX_FILE_SIZE;
+        return ($size === false) || $size > self::MAX_FILE_SIZE;
     }
 
 


### PR DESCRIPTION
Closes #62 
Fix if the file size is zero, the app evaluates the file as too large to scan