### PR TITLE
Feature/add compose and debug settings

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,6 +12,9 @@
 	"forwardPorts": [
 		80
 	],
+	"containerEnv": {
+		"XDEBUG_MODE": "debug,develop"
+	},
 	"customizations": {
 		"vscode": {
 			"extensions": [

--- a/.devcontainer/postCreateCommands.sh
+++ b/.devcontainer/postCreateCommands.sh
@@ -1,11 +1,17 @@
 #!/bin/bash
 
 sudo apt-get update 
-sudo apt-get install -y bash-completion vim
+sudo apt-get install -y bash-completion vim iputils-ping telnet
 sudo bash -c "docker completion bash > /usr/share/bash-completion/completions/docker"
 sudo bash -c "composer completion bash > /usr/share/bash-completion/completions/composer"
 sudo bash -c "npm completion > /usr/share/bash-completion/completions/npm"
 
 echo ". /usr/share/bash-completion/bash_completion" >> /home/vscode/.bashrc
+
+NEXTCLOUD_VERSION=$(grep -oP "[0-9]+\.[0-9]+\.[0-9]+" install.sh)
+git clone --depth 1 --recurse-submodules --single-branch --branch v$NEXTCLOUD_VERSION git@github.com:nextcloud/server.git ./nextcloud-server
+cd nextcloud-server
+git submodule update --init
+cd -
 
 ./install.sh

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -2,7 +2,7 @@ name: Makefile CI
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "*"]
     tags: ["*"]
   pull_request:
     branches: ["*"]

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -6,6 +6,7 @@ on:
     tags: ["*"]
   pull_request:
     branches: ["*"]
+  workflow_dispatch:
 
 jobs:
   define-matrix:

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -1,11 +1,10 @@
-name: Makefile CI
+name: Build and Test
 
 on:
   push:
-    branches: ["main", "*"]
+    branches: ["main"]
     tags: ["*"]
   pull_request:
-    branches: ["*"]
   workflow_dispatch:
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,5 @@ js/
 .uuid
 eicar.com.txt
 tmp/
+
+nextcloud-server/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,24 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "Listen for XDebug remote",
+            "type": "php",
+            "request": "launch",
+            "port": 9080,
+            "pathMappings": {
+                "/var/www/html/": "${workspaceFolder}/nextcloud-server",
+                "/var/www/html/apps/gdatavaas": "${workspaceFolder}/",
+            },
+            "runtimeArgs": [
+                "-dxdebug.mode=debug",
+                "-dxdebug.start_with_request=yes",
+                "-dxdebug.client_host=nextcloud-server",
+                "-dxdebug.client_port=9080",
+                "-S",
+                "localhost:0"
+            ],
+        },
+        {
             "name": "Listen for Xdebug",
             "type": "php",
             "request": "launch",

--- a/Dockerfile.Nextcloud
+++ b/Dockerfile.Nextcloud
@@ -2,7 +2,7 @@ ARG NEXTCLOUD_VERSION=29.0.4
 
 FROM nextcloud:${NEXTCLOUD_VERSION}
 
-RUN apt update && apt install -y less vim
+RUN apt update && apt install -y less vim telnet iputils-ping
 RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar \
     && chmod +x wp-cli.phar \
     && mv wp-cli.phar /usr/local/bin/wp

--- a/Dockerfile.Nextcloud
+++ b/Dockerfile.Nextcloud
@@ -1,0 +1,11 @@
+ARG NEXTCLOUD_VERSION=29.0.4
+
+FROM nextcloud:${NEXTCLOUD_VERSION}
+
+RUN apt update && apt install -y less vim
+RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar \
+    && chmod +x wp-cli.phar \
+    && mv wp-cli.phar /usr/local/bin/wp
+ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN install-php-extensions gd xdebug
+COPY xdebug.ini /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini

--- a/compose-install.yaml
+++ b/compose-install.yaml
@@ -1,0 +1,35 @@
+services:
+  nextcloud-container:
+    build:
+      context: .
+      dockerfile: Dockerfile.Nextcloud
+      args:
+        - NEXTCLOUD_VERSION=${NEXTCLOUD_VERSION:-29.0.3}
+    environment:
+      - XDEBUG_MODE=${XDEBUG_MODE:-develop}
+    ports:
+      - "80:80"
+    container_name: nextcloud-container
+    hostname: nextcloud-container
+    depends_on:
+      - smtp
+    restart: unless-stopped
+    networks:
+      - nextcloud-network
+    healthcheck:
+      test: 'php occ status | grep "installed: false"'
+      interval: 5s
+      timeout: 2s
+      retries: 10
+  smtp:
+    image: rnwood/smtp4dev:v3
+    container_name: smtp
+    hostname: smtp
+    restart: unless-stopped
+    ports:
+      - "8081:80"
+    networks:
+      - nextcloud-network
+
+networks:
+  nextcloud-network:

--- a/compose-install.yaml
+++ b/compose-install.yaml
@@ -26,6 +26,8 @@ services:
     container_name: smtp
     hostname: smtp
     restart: unless-stopped
+    environment:
+      ServerOptions__DisableIPv6: true
     ports:
       - "8081:80"
     networks:

--- a/compose.yaml
+++ b/compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 services:
   
   nextcloud-server:
-    image: nextcloud:29.0.3-fpm
+    image: nextcloud:29.0.4-fpm
     container_name: nextcloud-server
     hostname: nextcloud-server
     environment:

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 		"coduo/php-humanizer": "^5.0"
 	},
 	"require-dev": {
-		"nextcloud/ocp": "v29.0.3",
+		"nextcloud/ocp": "v29.0.4",
 		"psalm/phar": "5.25.0",
 		"nextcloud/coding-standard": "v1.2.1",
 		"phpunit/phpunit": "^11.2",

--- a/install.sh
+++ b/install.sh
@@ -63,9 +63,9 @@ docker exec --user www-data -i nextcloud-container php occ config:app:set gdatav
 docker exec --user www-data -i nextcloud-container php occ config:app:set gdatavaas notifyMails --value="test@example.com"
 docker exec --user www-data -i nextcloud-container php occ config:app:set gdatavaas sendMailOnVirusUpload --value=true
 docker exec --user www-data -i nextcloud-container php occ config:system:set mail_smtpmode --value="smtp"
-docker exec --user www-data -i nextcloud-container php occ config:system:set mail_smtphost --value="smtp-server"
+docker exec --user www-data -i nextcloud-container php occ config:system:set mail_smtphost --value="smtp"
 docker exec --user www-data -i nextcloud-container php occ config:system:set mail_smtpport --value="25"
-docker exec --user www-data -i nextcloud-container php occ config:system:set mail_from_address --value="test"
+docker exec --user www-data -i nextcloud-container php occ config:system:set mail_from_address --value="test@example.com"
 docker exec --user www-data -i nextcloud-container php occ config:system:set mail_domain --value="example.com"
 docker exec --user www-data -i nextcloud-container php occ user:setting admin settings email test@example.com
 

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-NEXTCLOUD_VERSION=${NEXTCLOUD_VERSION:-29.0.3}
+NEXTCLOUD_VERSION=${NEXTCLOUD_VERSION:-29.0.4}
 XDEBUG_MODE=${XDEBUG_MODE:-develop}
 
 source .env-local || echo "No .env-local file found."

--- a/install.sh
+++ b/install.sh
@@ -1,21 +1,15 @@
 #!/bin/bash
 
-NEXTCLOUD_VERSION=${1:-29}
+NEXTCLOUD_VERSION=${NEXTCLOUD_VERSION:-29.0.3}
+XDEBUG_MODE=${XDEBUG_MODE:-develop}
 
 source .env-local || echo "No .env-local file found."
 
 setup_nextcloud () {
   echo "setup nextcloud"
-  docker stop nextcloud-container || echo "No container to stop"
-  sleep 1
-  docker network create nextcloud
-  docker run --quiet -d --name nextcloud-container --network nextcloud --rm --publish 80:80 nextcloud:"$NEXTCLOUD_VERSION"
-
-  until docker exec --user www-data -i nextcloud-container php occ status | grep "installed: false"
-  do
-    echo "waiting for nextcloud to be initialized"
-    sleep 2
-  done
+  docker compose -f compose-install.yaml kill
+  docker compose -f compose-install.yaml rm --force --stop --volumes
+  docker compose -f compose-install.yaml up --build --quiet-pull --wait -d --force-recreate --renew-anon-volumes --remove-orphans
 
   echo "copy config for empty skeleton"
   docker cp ./empty-skeleton.config.php nextcloud-container:/var/www/html/config/config.php
@@ -74,13 +68,6 @@ docker exec --user www-data -i nextcloud-container php occ config:system:set mai
 docker exec --user www-data -i nextcloud-container php occ config:system:set mail_from_address --value="test"
 docker exec --user www-data -i nextcloud-container php occ config:system:set mail_domain --value="example.com"
 docker exec --user www-data -i nextcloud-container php occ user:setting admin settings email test@example.com
-
-# Setup the SMTP test server
-echo "setup smtp test server"
-docker stop smtp-server || echo "No container to stop"
-docker container rm smtp-server || echo "No container to remove"
-sleep 1
-docker run --quiet --network nextcloud -d --name smtp-server -p 8081:80 rnwood/smtp4dev:v3
 
 source install.local || echo "No additional install script found."
 

--- a/tests/bats/.env-test
+++ b/tests/bats/.env-test
@@ -1,0 +1,6 @@
+export FOLDER_PREFIX=./tmp/functionality-parallel
+export TESTUSER=testuser
+export TESTUSER_PASSWORD=myfancysecurepassword234
+export EICAR_STRING='X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*'
+export CLEAN_STRING='nothingwronghere'
+export DOCKER_EXEC_WITH_USER='docker exec --env XDEBUG_MODE=off --user www-data'

--- a/tests/bats/functionality-sequential.bats
+++ b/tests/bats/functionality-sequential.bats
@@ -131,14 +131,11 @@ setup_file() {
 
 @test "test mailing on eicar upload" {
     echo $EICAR_STRING | curl --silent -w "%{http_code}" -u admin:admin -T - http://127.0.0.1/remote.php/dav/files/admin/functionality-sequential.eicar.com.txt
-    sleep 2
-    
-    until RESULT=$(curl -X 'GET' 'http://127.0.0.1:8081/api/Messages/new?mailboxName=Default&pageSize=1' -H 'accept: application/json')
-    do
-        echo "waiting for mail server to be ready"
-        sleep 2
-    done
-    
+    sleep 1
+
+    RESULT=$(curl -X 'GET' 'http://127.0.0.1:8081/api/Messages/new?mailboxName=Default&pageSize=1' -H 'accept: application/json')
+
+    echo $RESULT
     [[ $RESULT =~ "Infected file upload" ]]
     
     curl --silent -q -u admin:admin -X DELETE http://127.0.0.1/remote.php/dav/files/admin/functionality-sequential.eicar.com.txt  

--- a/tests/bats/functionality-sequential.bats
+++ b/tests/bats/functionality-sequential.bats
@@ -1,25 +1,24 @@
 #!/usr/bin/env bats
 
-FOLDER_PREFIX=./tmp/functionality-sequential
-TESTUSER=testuser
-TESTUSER_PASSWORD=myfancysecurepassword234
-EICAR_STRING='X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*'
-CLEAN_STRING='nothingwronghere'
-
 setup_file() {
+    source tests/bats/.env-test || return 1
+    source .env-local || echo "No .env-local file found."
     mkdir -p $FOLDER_PREFIX/
     curl --output $FOLDER_PREFIX/pup.exe http://amtso.eicar.org/PotentiallyUnwanted.exe
-    docker exec --env OC_PASS=$TESTUSER_PASSWORD --user www-data nextcloud-container php occ user:add $TESTUSER --password-from-env || echo "already exists"
-    docker exec -u www-data -i nextcloud-container mkdir -p /var/www/html/data/$TESTUSER/files
+    $DOCKER_EXEC_WITH_USER --env OC_PASS=$TESTUSER_PASSWORD nextcloud-container php occ user:add $TESTUSER --password-from-env || echo "already exists"
+    $DOCKER_EXEC_WITH_USER nextcloud-container mkdir -p /var/www/html/data/$TESTUSER/files
 
-    docker exec --user www-data -i nextcloud-container php occ config:app:set gdatavaas clientSecret --value="$CLIENT_SECRET"
+    $DOCKER_EXEC_WITH_USER nextcloud-container php occ config:app:set gdatavaas clientSecret --value="$CLIENT_SECRET"
     BATS_NO_PARALLELIZE_WITHIN_FILE=true
+    # this is cache busting
+    $DOCKER_EXEC_WITH_USER nextcloud-container php occ files:scan --all
+    docker exec nextcloud-container chown -R www-data:www-data /var/www/html/
 }
 
 @test "test upload when vaas does not function" {
-    docker exec --user www-data -i nextcloud-container php occ config:app:set gdatavaas clientSecret --value="WRONG_PASSWORD"
+    $DOCKER_EXEC_WITH_USER nextcloud-container php occ config:app:set gdatavaas clientSecret --value="WRONG_PASSWORD"
     RESULT=$(echo $EICAR_STRING | curl --silent -w "%{http_code}" -u admin:admin -T - http://127.0.0.1/remote.php/dav/files/admin/functionality-sequential.eicar.com.txt)
-    docker exec --user www-data -i nextcloud-container php occ config:app:set gdatavaas clientSecret --value="$CLIENT_SECRET"
+    $DOCKER_EXEC_WITH_USER nextcloud-container php occ config:app:set gdatavaas clientSecret --value="$CLIENT_SECRET"
     curl --silent -q -u admin:admin -X DELETE http://127.0.0.1/remote.php/dav/files/admin/functionality-sequential.eicar.com.txt
     
     echo "Actual: $RESULT"
@@ -27,37 +26,36 @@ setup_file() {
 }
 
 @test "test croned scan for admin files" {
-    docker exec --user www-data -i nextcloud-container php occ config:app:set gdatavaas clientSecret --value="WRONG_PASSWORD"
+    $DOCKER_EXEC_WITH_USER nextcloud-container php occ config:app:set gdatavaas clientSecret --value="WRONG_PASSWORD"
     echo $EICAR_STRING | curl --silent -w "%{http_code}" -u admin:admin -T - http://127.0.0.1/remote.php/dav/files/admin/admin.functionality-sequential.eicar.com.txt
     curl --silent -w "%{http_code}" -u admin:admin -T $FOLDER_PREFIX/pup.exe http://127.0.0.1/remote.php/dav/files/admin/admin.pup.exe
     echo $CLEAN_STRING | curl --silent -w "%{http_code}" -u admin:admin -T - http://127.0.0.1/remote.php/dav/files/admin/admin.functionality-sequential.clean.txt
 
-    docker exec --user www-data -i nextcloud-container php occ config:app:set gdatavaas clientSecret --value="$CLIENT_SECRET"
+    $DOCKER_EXEC_WITH_USER nextcloud-container php occ config:app:set gdatavaas clientSecret --value="$CLIENT_SECRET"
 
     # check for unscanned tag
-    [[ $(docker exec -i --user www-data nextcloud-container php occ gdatavaas:get-tags-for-file admin/files/admin.functionality-sequential.eicar.com.txt | grep "Unscanned") ]]
-    [[ $(docker exec -i --user www-data nextcloud-container php occ gdatavaas:get-tags-for-file admin/files/admin.functionality-sequential.eicar.com.txt | wc -l ) -eq "1" ]]
+    [[ $($DOCKER_EXEC_WITH_USER nextcloud-container php occ gdatavaas:get-tags-for-file admin/files/admin.functionality-sequential.eicar.com.txt | grep "Unscanned") ]]
+    [[ $($DOCKER_EXEC_WITH_USER nextcloud-container php occ gdatavaas:get-tags-for-file admin/files/admin.functionality-sequential.eicar.com.txt | wc -l ) -eq "1" ]]
 
-    [[ $(docker exec -i --user www-data nextcloud-container php occ gdatavaas:get-tags-for-file admin/files/admin.pup.exe | grep "Unscanned" ) ]]
-    [[ $(docker exec -i --user www-data nextcloud-container php occ gdatavaas:get-tags-for-file admin/files/admin.pup.exe | wc -l ) -eq "1" ]]
+    [[ $($DOCKER_EXEC_WITH_USER nextcloud-container php occ gdatavaas:get-tags-for-file admin/files/admin.pup.exe | grep "Unscanned" ) ]]
+    [[ $($DOCKER_EXEC_WITH_USER nextcloud-container php occ gdatavaas:get-tags-for-file admin/files/admin.pup.exe | wc -l ) -eq "1" ]]
 
-    [[ $(docker exec -i --user www-data nextcloud-container php occ gdatavaas:get-tags-for-file admin/files/admin.functionality-sequential.clean.txt | grep "Unscanned" ) ]]
-    [[ $(docker exec -i --user www-data nextcloud-container php occ gdatavaas:get-tags-for-file admin/files/admin.functionality-sequential.clean.txt | wc -l ) -eq "1" ]]
+    [[ $($DOCKER_EXEC_WITH_USER nextcloud-container php occ gdatavaas:get-tags-for-file admin/files/admin.functionality-sequential.clean.txt | grep "Unscanned" ) ]]
+    [[ $($DOCKER_EXEC_WITH_USER nextcloud-container php occ gdatavaas:get-tags-for-file admin/files/admin.functionality-sequential.clean.txt | wc -l ) -eq "1" ]]
 
-    docker exec -i --user www-data nextcloud-container php occ gdatavaas:scan
+    $DOCKER_EXEC_WITH_USER nextcloud-container php occ gdatavaas:scan
 
     # check for tags (only one specific should exist for each file)
-    [[ $(docker exec -i --user www-data nextcloud-container php occ gdatavaas:get-tags-for-file admin/files/admin.functionality-sequential.eicar.com.txt | grep "Malicious") ]]
-    [[ $(docker exec -i --user www-data nextcloud-container php occ gdatavaas:get-tags-for-file admin/files/admin.functionality-sequential.eicar.com.txt | wc -l ) -eq "1" ]]
+    [[ $($DOCKER_EXEC_WITH_USER nextcloud-container php occ gdatavaas:get-tags-for-file admin/files/admin.functionality-sequential.eicar.com.txt | grep "Malicious") ]]
+    [[ $($DOCKER_EXEC_WITH_USER nextcloud-container php occ gdatavaas:get-tags-for-file admin/files/admin.functionality-sequential.eicar.com.txt | wc -l ) -eq "1" ]]
 
-    [[ $(docker exec -i --user www-data nextcloud-container php occ gdatavaas:get-tags-for-file admin/files/admin.pup.exe | grep "Pup" ) ]]
-    [[ $(docker exec -i --user www-data nextcloud-container php occ gdatavaas:get-tags-for-file admin/files/admin.pup.exe | wc -l ) -eq "1" ]]
+    [[ $($DOCKER_EXEC_WITH_USER nextcloud-container php occ gdatavaas:get-tags-for-file admin/files/admin.pup.exe | grep "Pup" ) ]]
+    [[ $($DOCKER_EXEC_WITH_USER nextcloud-container php occ gdatavaas:get-tags-for-file admin/files/admin.pup.exe | wc -l ) -eq "1" ]]
 
-    [[ $(docker exec -i --user www-data nextcloud-container php occ gdatavaas:get-tags-for-file admin/files/admin.functionality-sequential.clean.txt | grep "Clean" ) ]]
-    [[ $(docker exec -i --user www-data nextcloud-container php occ gdatavaas:get-tags-for-file admin/files/admin.functionality-sequential.clean.txt | wc -l ) -eq "1" ]]
+    [[ $($DOCKER_EXEC_WITH_USER nextcloud-container php occ gdatavaas:get-tags-for-file admin/files/admin.functionality-sequential.clean.txt | grep "Clean" ) ]]
+    [[ $($DOCKER_EXEC_WITH_USER nextcloud-container php occ gdatavaas:get-tags-for-file admin/files/admin.functionality-sequential.clean.txt | wc -l ) -eq "1" ]]
 
-    docker exec nextcloud-container chown -R www-data:www-data /var/www/html/
-    LOGS=$(docker exec --user www-data -i nextcloud-container tail -5000 data/nextcloud.log | egrep "admin.functionality-sequential.eicar.com.txt|admin.functionality-sequential.clean.txt|admin.pup.exe" )
+    LOGS=$($DOCKER_EXEC_WITH_USER -i nextcloud-container tail -5000 data/nextcloud.log | egrep "admin.functionality-sequential.eicar.com.txt|admin.functionality-sequential.clean.txt|admin.pup.exe" )
 
     curl --silent -q -u admin:admin -X DELETE http://127.0.0.1/remote.php/dav/files/admin/admin.functionality-sequential.eicar.com.txt
     curl --silent -q -u admin:admin -X DELETE http://127.0.0.1/remote.php/dav/files/admin/admin.pup.exe
@@ -69,38 +67,37 @@ setup_file() {
 }
 
 @test "test croned scan for testuser files" {
-    docker exec --user www-data -i nextcloud-container php occ config:app:set gdatavaas clientSecret --value="WRONG_PASSWORD"
+    $DOCKER_EXEC_WITH_USER -i nextcloud-container php occ config:app:set gdatavaas clientSecret --value="WRONG_PASSWORD"
     
     echo $EICAR_STRING |curl --silent -w "%{http_code}" -u $TESTUSER:$TESTUSER_PASSWORD -T - http://127.0.0.1/remote.php/dav/files/$TESTUSER/$TESTUSER.functionality-sequential.eicar.com.txt
     curl --silent -w "%{http_code}" -u $TESTUSER:$TESTUSER_PASSWORD -T $FOLDER_PREFIX/pup.exe http://127.0.0.1/remote.php/dav/files/$TESTUSER/$TESTUSER.pup.exe
     echo $CLEAN_STRING |curl --silent -w "%{http_code}" -u $TESTUSER:$TESTUSER_PASSWORD -T - http://127.0.0.1/remote.php/dav/files/$TESTUSER/$TESTUSER.functionality-sequential.clean.txt
 
-    docker exec --user www-data -i nextcloud-container php occ config:app:set gdatavaas clientSecret --value="$CLIENT_SECRET"
+    $DOCKER_EXEC_WITH_USER -i nextcloud-container php occ config:app:set gdatavaas clientSecret --value="$CLIENT_SECRET"
 
     # check for unscanned tag
-    [[ $(docker exec -i --user www-data nextcloud-container php occ gdatavaas:get-tags-for-file $TESTUSER/files/$TESTUSER.functionality-sequential.eicar.com.txt | grep "Unscanned") ]]
-    [[ $(docker exec -i --user www-data nextcloud-container php occ gdatavaas:get-tags-for-file $TESTUSER/files/$TESTUSER.functionality-sequential.eicar.com.txt | wc -l ) -eq "1" ]]
+    [[ $($DOCKER_EXEC_WITH_USER nextcloud-container php occ gdatavaas:get-tags-for-file $TESTUSER/files/$TESTUSER.functionality-sequential.eicar.com.txt | grep "Unscanned") ]]
+    [[ $($DOCKER_EXEC_WITH_USER nextcloud-container php occ gdatavaas:get-tags-for-file $TESTUSER/files/$TESTUSER.functionality-sequential.eicar.com.txt | wc -l ) -eq "1" ]]
 
-    [[ $(docker exec -i --user www-data nextcloud-container php occ gdatavaas:get-tags-for-file $TESTUSER/files/$TESTUSER.pup.exe | grep "Unscanned" ) ]]
-    [[ $(docker exec -i --user www-data nextcloud-container php occ gdatavaas:get-tags-for-file $TESTUSER/files/$TESTUSER.pup.exe | wc -l ) -eq "1" ]]
+    [[ $($DOCKER_EXEC_WITH_USER nextcloud-container php occ gdatavaas:get-tags-for-file $TESTUSER/files/$TESTUSER.pup.exe | grep "Unscanned" ) ]]
+    [[ $($DOCKER_EXEC_WITH_USER nextcloud-container php occ gdatavaas:get-tags-for-file $TESTUSER/files/$TESTUSER.pup.exe | wc -l ) -eq "1" ]]
 
-    [[ $(docker exec -i --user www-data nextcloud-container php occ gdatavaas:get-tags-for-file $TESTUSER/files/$TESTUSER.functionality-sequential.clean.txt | grep "Unscanned" ) ]]
-    [[ $(docker exec -i --user www-data nextcloud-container php occ gdatavaas:get-tags-for-file $TESTUSER/files/$TESTUSER.functionality-sequential.clean.txt | wc -l ) -eq "1" ]]
+    [[ $($DOCKER_EXEC_WITH_USER nextcloud-container php occ gdatavaas:get-tags-for-file $TESTUSER/files/$TESTUSER.functionality-sequential.clean.txt | grep "Unscanned" ) ]]
+    [[ $($DOCKER_EXEC_WITH_USER nextcloud-container php occ gdatavaas:get-tags-for-file $TESTUSER/files/$TESTUSER.functionality-sequential.clean.txt | wc -l ) -eq "1" ]]
 
-    docker exec -i --user www-data nextcloud-container php occ gdatavaas:scan
+    $DOCKER_EXEC_WITH_USER nextcloud-container php occ gdatavaas:scan
 
     # check for tags (only one specific should exist for each file)
-    [[ $(docker exec -i --user www-data nextcloud-container php occ gdatavaas:get-tags-for-file $TESTUSER/files/$TESTUSER.functionality-sequential.eicar.com.txt | grep "Malicious") ]]
-    [[ $(docker exec -i --user www-data nextcloud-container php occ gdatavaas:get-tags-for-file $TESTUSER/files/$TESTUSER.functionality-sequential.eicar.com.txt | wc -l ) -eq "1" ]]
+    [[ $($DOCKER_EXEC_WITH_USER nextcloud-container php occ gdatavaas:get-tags-for-file $TESTUSER/files/$TESTUSER.functionality-sequential.eicar.com.txt | grep "Malicious") ]]
+    [[ $($DOCKER_EXEC_WITH_USER nextcloud-container php occ gdatavaas:get-tags-for-file $TESTUSER/files/$TESTUSER.functionality-sequential.eicar.com.txt | wc -l ) -eq "1" ]]
 
-    [[ $(docker exec -i --user www-data nextcloud-container php occ gdatavaas:get-tags-for-file $TESTUSER/files/$TESTUSER.pup.exe | grep "Pup" ) ]]
-    [[ $(docker exec -i --user www-data nextcloud-container php occ gdatavaas:get-tags-for-file $TESTUSER/files/$TESTUSER.pup.exe | wc -l ) -eq "1" ]]
+    [[ $($DOCKER_EXEC_WITH_USER nextcloud-container php occ gdatavaas:get-tags-for-file $TESTUSER/files/$TESTUSER.pup.exe | grep "Pup" ) ]]
+    [[ $($DOCKER_EXEC_WITH_USER nextcloud-container php occ gdatavaas:get-tags-for-file $TESTUSER/files/$TESTUSER.pup.exe | wc -l ) -eq "1" ]]
 
-    [[ $(docker exec -i --user www-data nextcloud-container php occ gdatavaas:get-tags-for-file $TESTUSER/files/$TESTUSER.functionality-sequential.clean.txt | grep "Clean" ) ]]
-    [[ $(docker exec -i --user www-data nextcloud-container php occ gdatavaas:get-tags-for-file $TESTUSER/files/$TESTUSER.functionality-sequential.clean.txt | wc -l ) -eq "1" ]]
+    [[ $($DOCKER_EXEC_WITH_USER nextcloud-container php occ gdatavaas:get-tags-for-file $TESTUSER/files/$TESTUSER.functionality-sequential.clean.txt | grep "Clean" ) ]]
+    [[ $($DOCKER_EXEC_WITH_USER nextcloud-container php occ gdatavaas:get-tags-for-file $TESTUSER/files/$TESTUSER.functionality-sequential.clean.txt | wc -l ) -eq "1" ]]
 
-    docker exec nextcloud-container chown -R www-data:www-data /var/www/html/
-    LOGS=$(docker exec --user www-data -i nextcloud-container tail -5000 data/nextcloud.log | egrep "$TESTUSER.functionality-sequential.eicar.com.txt|$TESTUSER.functionality-sequential.clean.txt|$TESTUSER.pup.exe")
+    LOGS=$($DOCKER_EXEC_WITH_USER -i nextcloud-container tail -5000 data/nextcloud.log | egrep "$TESTUSER.functionality-sequential.eicar.com.txt|$TESTUSER.functionality-sequential.clean.txt|$TESTUSER.pup.exe")
 
     curl --silent -q -u $TESTUSER:$TESTUSER_PASSWORD -X DELETE http://127.0.0.1/remote.php/dav/files/$TESTUSER/$TESTUSER.functionality-sequential.eicar.com.txt
     curl --silent -q -u $TESTUSER:$TESTUSER_PASSWORD -X DELETE http://127.0.0.1/remote.php/dav/files/$TESTUSER/$TESTUSER.pup.exe
@@ -113,19 +110,19 @@ setup_file() {
 }
 
 @test "test when unscanned tag is deactivated" {
-    docker exec --user www-data -i nextcloud-container php occ config:app:set gdatavaas clientSecret --value="WRONG_PASSWORD"
-    docker exec --user www-data -i nextcloud-container php occ config:app:set gdatavaas disableUnscannedTag --value="true"
+    $DOCKER_EXEC_WITH_USER -i nextcloud-container php occ config:app:set gdatavaas clientSecret --value="WRONG_PASSWORD"
+    $DOCKER_EXEC_WITH_USER -i nextcloud-container php occ config:app:set gdatavaas disableUnscannedTag --value="true"
     
     echo $EICAR_STRING |curl --silent -w "%{http_code}" -u $TESTUSER:$TESTUSER_PASSWORD -T - http://127.0.0.1/remote.php/dav/files/$TESTUSER/$TESTUSER.functionality-sequential.eicar.com.txt
     echo $CLEAN_STRING |curl --silent -w "%{http_code}" -u $TESTUSER:$TESTUSER_PASSWORD -T - http://127.0.0.1/remote.php/dav/files/$TESTUSER/$TESTUSER.functionality-sequential.clean.txt
 
-    docker exec --user www-data -i nextcloud-container php occ config:app:set gdatavaas clientSecret --value="$CLIENT_SECRET"
+    $DOCKER_EXEC_WITH_USER -i nextcloud-container php occ config:app:set gdatavaas clientSecret --value="$CLIENT_SECRET"
 
     # check for unscanned tag
-    [[ $(docker exec -i --user www-data nextcloud-container php occ gdatavaas:get-tags-for-file $TESTUSER/files/$TESTUSER.functionality-sequential.eicar.com.txt | grep "Unscanned" | wc -l) -eq "0" ]]
-    [[ $(docker exec -i --user www-data nextcloud-container php occ gdatavaas:get-tags-for-file $TESTUSER/files/$TESTUSER.functionality-sequential.clean.txt | grep "Unscanned" | wc -l ) -eq "0" ]]
+    [[ $($DOCKER_EXEC_WITH_USER nextcloud-container php occ gdatavaas:get-tags-for-file $TESTUSER/files/$TESTUSER.functionality-sequential.eicar.com.txt | grep "Unscanned" | wc -l) -eq "0" ]]
+    [[ $($DOCKER_EXEC_WITH_USER nextcloud-container php occ gdatavaas:get-tags-for-file $TESTUSER/files/$TESTUSER.functionality-sequential.clean.txt | grep "Unscanned" | wc -l ) -eq "0" ]]
 
-    docker exec --user www-data -i nextcloud-container php occ config:app:set gdatavaas disableUnscannedTag --value="false"
+    $DOCKER_EXEC_WITH_USER -i nextcloud-container php occ config:app:set gdatavaas disableUnscannedTag --value="false"
 
     curl --silent -q -u $TESTUSER:$TESTUSER_PASSWORD -X DELETE http://127.0.0.1/remote.php/dav/files/$TESTUSER/$TESTUSER.functionality-sequential.eicar.com.txt
     curl --silent -q -u $TESTUSER:$TESTUSER_PASSWORD -X DELETE http://127.0.0.1/remote.php/dav/files/$TESTUSER/$TESTUSER.functionality-sequential.clean.txt

--- a/tests/bats/functionality-sequential.bats
+++ b/tests/bats/functionality-sequential.bats
@@ -56,6 +56,7 @@ setup_file() {
     [[ $(docker exec -i --user www-data nextcloud-container php occ gdatavaas:get-tags-for-file admin/files/admin.functionality-sequential.clean.txt | grep "Clean" ) ]]
     [[ $(docker exec -i --user www-data nextcloud-container php occ gdatavaas:get-tags-for-file admin/files/admin.functionality-sequential.clean.txt | wc -l ) -eq "1" ]]
 
+    docker exec nextcloud-container chown -R www-data:www-data /var/www/html/
     LOGS=$(docker exec --user www-data -i nextcloud-container tail -5000 data/nextcloud.log | egrep "admin.functionality-sequential.eicar.com.txt|admin.functionality-sequential.clean.txt|admin.pup.exe" )
 
     curl --silent -q -u admin:admin -X DELETE http://127.0.0.1/remote.php/dav/files/admin/admin.functionality-sequential.eicar.com.txt
@@ -98,6 +99,7 @@ setup_file() {
     [[ $(docker exec -i --user www-data nextcloud-container php occ gdatavaas:get-tags-for-file $TESTUSER/files/$TESTUSER.functionality-sequential.clean.txt | grep "Clean" ) ]]
     [[ $(docker exec -i --user www-data nextcloud-container php occ gdatavaas:get-tags-for-file $TESTUSER/files/$TESTUSER.functionality-sequential.clean.txt | wc -l ) -eq "1" ]]
 
+    docker exec nextcloud-container chown -R www-data:www-data /var/www/html/
     LOGS=$(docker exec --user www-data -i nextcloud-container tail -5000 data/nextcloud.log | egrep "$TESTUSER.functionality-sequential.eicar.com.txt|$TESTUSER.functionality-sequential.clean.txt|$TESTUSER.pup.exe")
 
     curl --silent -q -u $TESTUSER:$TESTUSER_PASSWORD -X DELETE http://127.0.0.1/remote.php/dav/files/$TESTUSER/$TESTUSER.functionality-sequential.eicar.com.txt

--- a/xdebug.ini
+++ b/xdebug.ini
@@ -1,0 +1,9 @@
+zend_extension=xdebug.so
+xdebug.client_host=nextcloud-server
+xdebug.client_port=9080
+xdebug.start_with_request=yes
+xdebug.log=/tmp/xdebug.log
+xdebug.mode=debug
+xdebug.discover_client_host=1
+xdebug.idekey=PHPSTORM
+xdebug.remote_handler=dbgp


### PR DESCRIPTION
With this change, when you start the devcontainer, all you additionally need to do is start the remote debugger.

It will checkout the current (in the install.sh configured) version from nextcloud into the nextcloud-server folder and with this launch-configuration map the source to it.

https://github.com/GDATASoftwareAG/nextcloud-gdata-antivirus/blob/feature/add-compose-and-debug-settings/.vscode/launch.json#L7-L24

It also moves the container start into a compose file under [compose-install.yaml](https://github.com/GDATASoftwareAG/nextcloud-gdata-antivirus/blob/feature/add-compose-and-debug-settings/compose-install.yaml)

In the nextcloud-container that start now with the ./install.sh script xdebug is already installed.

So all you need to do is set your breakpoints

![image](https://github.com/user-attachments/assets/970df7fc-16f0-4895-b21b-9e68c7440943)

Start the remote debugger configuration

![image](https://github.com/user-attachments/assets/4b8832ee-58de-4cee-a2c9-9a92648c83a5)

When you now surf to the nextcloud installation in your browser the debugger will hold on the breakpoint.

![image](https://github.com/user-attachments/assets/96c4f6bf-fecc-4db8-b99f-d8bebbe9b65a)

![image](https://github.com/user-attachments/assets/45e8577b-7946-456d-89e3-4e37dc40574c)

Also working on the plugin code

![image](https://github.com/user-attachments/assets/efb4e5d1-af3d-414e-bbaa-f58eba31f2ac)
