### PR TITLE
Support PHP 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
 		"nextcloud/ocp": "v29.0.4",
 		"psalm/phar": "5.25.0",
 		"nextcloud/coding-standard": "v1.2.1",
-		"phpunit/phpunit": "^11.2",
-		"symfony/console": "^7.1"
+		"phpunit/phpunit": "10.5.30",
+		"symfony/console": "6.4.10"
 	},
 	"autoload": {
 		"psr-4": {
@@ -38,7 +38,7 @@
 			"composer/package-versions-deprecated": true
 		},
 		"platform": {
-			"php": "8.2"
+			"php": "8.1"
 		}
 	}
 }


### PR DESCRIPTION
Lowest version, Nextcloud supports, is PHP 8.1. 