### PR TITLE
adds some sanity checks before the actual scan

### DIFF
--- a/lib/Service/VerdictService.php
+++ b/lib/Service/VerdictService.php
@@ -37,7 +37,7 @@ class VerdictService {
 	private ?Vaas $vaas = null;
 	private LoggerInterface $logger;
 
-	private string $lastLocalPath = "";
+	private string $lastLocalPath = '';
 	private ?VaasVerdict $lastVaasVerdict = null;
 
 	public function __construct(LoggerInterface $logger, IAppConfig $appConfig, FileService $fileService, TagService $tagService) {
@@ -71,9 +71,15 @@ class VerdictService {
 	public function scanFileById(int $fileId): VaasVerdict {
 		$node = $this->fileService->getNodeFromFileId($fileId);
 		$filePath = $node->getStorage()->getLocalFile($node->getInternalPath());
+		if (file_exists($filePath) === false) {
+			$this->logger->debug('Could not Scan File. File does not exist: ' . $filePath);
+		}
+		if (is_dir($filePath)) {
+			$this->logger->debug('Could not Scan File. File is a directory: ' . $filePath);
+		}
 		if (self::isFileTooLargeToScan($filePath)) {
 			$this->tagService->setTag($fileId, TagService::WONT_SCAN, silent: true);
-			throw new EntityTooLargeException("File is too large");
+			throw new EntityTooLargeException('File is too large');
 		}
 
 		if (!$this->isAllowedToScan($filePath)) {
@@ -82,9 +88,9 @@ class VerdictService {
 
 		$verdict = $this->scan($filePath);
 
-		$this->logger->info("VaaS scan result for " . $node->getName() . " (" . $fileId . "): Verdict: "
-			. $verdict->Verdict->value . ", Detection: " . $verdict->Detection . ", SHA256: " . $verdict->Sha256 .
-			", FileType: " . $verdict->FileType . ", MimeType: " . $verdict->MimeType . ", UUID: " . $verdict->Guid);
+		$this->logger->info('VaaS scan result for ' . $node->getName() . ' (' . $fileId . '): Verdict: '
+			. $verdict->Verdict->value . ', Detection: ' . $verdict->Detection . ', SHA256: ' . $verdict->Sha256 .
+			', FileType: ' . $verdict->FileType . ', MimeType: ' . $verdict->MimeType . ', UUID: ' . $verdict->Guid);
 
 		$this->tagFile($fileId, $verdict->Verdict->value);
 
@@ -205,7 +211,7 @@ class VerdictService {
 		if (empty($scanOnlyThis)) {
 			return [];
 		}
-		return explode(",", $scanOnlyThis);
+		return explode(',', $scanOnlyThis);
 	}
 	
 	/**
@@ -218,7 +224,7 @@ class VerdictService {
 		if (empty($doNotScanThis)) {
 			return [];
 		}
-		return explode(",", $doNotScanThis);
+		return explode(',', $doNotScanThis);
 	}
 
 	/**
@@ -238,7 +244,7 @@ class VerdictService {
 	public function getAuthenticator(string $authMethod): ClientCredentialsGrantAuthenticator|ResourceOwnerPasswordGrantAuthenticator {
 		if ($authMethod === 'ResourceOwnerPassword') {
 			return new ResourceOwnerPasswordGrantAuthenticator(
-				"nextcloud-customer",
+				'nextcloud-customer',
 				$this->username,
 				$this->password,
 				$this->tokenEndpoint
@@ -250,7 +256,7 @@ class VerdictService {
 				$this->tokenEndpoint
 			);
 		} else {
-			throw new VaasAuthenticationException("Invalid auth method: " . $authMethod);
+			throw new VaasAuthenticationException('Invalid auth method: ' . $authMethod);
 		}
 	}
 
@@ -272,7 +278,7 @@ class VerdictService {
 	 */
 	public function isAllowedToScan(string $filePath): bool {
 		$doNotScanThis = $this->getDoNotScanThis();
-		$this->logger->debug("doNotScanThis: " . implode(", ", $doNotScanThis));
+		$this->logger->debug('doNotScanThis: ' . implode(', ', $doNotScanThis));
 		foreach ($doNotScanThis as $doNotScanThisItem) {
 			if (str_contains(strtolower($filePath), strtolower($doNotScanThisItem))) {
 				return false;
@@ -282,7 +288,7 @@ class VerdictService {
 		if (count($scanOnlyThis) === 0) {
 			return true;
 		}
-		$this->logger->debug("scanOnlyThis: " . implode(", ", $scanOnlyThis));
+		$this->logger->debug('scanOnlyThis: ' . implode(', ', $scanOnlyThis));
 		foreach ($scanOnlyThis as $scanOnlyThisItem) {
 			if (str_contains(strtolower($filePath), strtolower($scanOnlyThisItem))) {
 				return true;


### PR DESCRIPTION
The change with the quotes where done by my linter but I would still suggest to apply them because fixed strings should always use ' while " should only be used if you actually want to substitute a variable into the string.

As you can see on the [Strings page of the PHP Docs](https://www.php.net/manual/en/language.types.string.php#language.types.string.syntax.single) with the double quotes many interpretations are done that can basically be avoided doing by mistake when using single quotes.