### PR TITLE
Support PHP < 8.3

### DIFF
--- a/lib/Service/ScanService.php
+++ b/lib/Service/ScanService.php
@@ -14,7 +14,7 @@ use VaasSdk\Exceptions\VaasAuthenticationException;
 
 class ScanService {
 	
-	private const int SCAN_TIME_SECONDS = 120;
+	private const SCAN_TIME_SECONDS = 120;
 	
 	private TagService $tagService;
 	private VerdictService $verdictService;


### PR DESCRIPTION
fix: correct syntax error in ScanService.php for constant declaration for PHP < 8.3 (#227)