### PR TITLE
Outsource scan actions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ all: build
 
 # Fetches dependencies and builds it
 .PHONY: build
-build:
+build: oc
 ifneq (,$(wildcard $(CURDIR)/composer.json))
 	make composer
 endif
@@ -36,7 +36,7 @@ endif
 # Installs and updates the composer dependencies. If composer is not installed
 # a copy is fetched from the web
 .PHONY: composer
-composer:
+composer: oc
 ifeq (,$(composer))
 	@echo "No composer command available, downloading a copy from the web"
 	mkdir -p $(build_tools_directory)
@@ -95,7 +95,6 @@ distclean: clean
 	rm -rf node_modules
 	rm -rf js/vendor
 	rm -rf js/node_modules
-	rm -rf nextcloud-server
 	rm -rf build
 	rm -f composer.lock
 
@@ -120,6 +119,7 @@ appstore: build
 	--exclude-vcs \
 	--exclude="$(source_build_directory)/.git" \
 	--exclude="$(source_build_directory)/.github" \
+	--exclude="$(source_build_directory)/nextcloud-server" \
 	--exclude="$(source_build_directory)/composer.json" \
 	--exclude="$(source_build_directory)/composer.json.license" \
 	--exclude="$(source_build_directory)/babel.config.js" \

--- a/lib/Service/VerdictService.php
+++ b/lib/Service/VerdictService.php
@@ -246,11 +246,6 @@ class VerdictService {
 		switch ($tagName) {
 			case TagService::MALICIOUS:
 				$this->tagService->setTag($fileId, TagService::MALICIOUS, silent: false);
-				try {
-					$this->fileService->setMaliciousPrefixIfActivated($fileId);
-					$this->fileService->moveFileToQuarantineFolderIfDefined($fileId);
-				} catch (Exception) {
-				}
 				break;
 			case TagService::PUP:
 				$this->tagService->setTag($fileId, TagService::PUP, silent: false);


### PR DESCRIPTION
Outsource the consequences of a file scan from tag function, as this is not just tagging and caused a bug in the event handler where the quarantine was created empty.