### PR TITLE
Fix "Groupfolder files are not found by background scan" #289

### DIFF
--- a/lib/Service/FileService.php
+++ b/lib/Service/FileService.php
@@ -82,6 +82,12 @@ class FileService {
 				return $node;
 			}
 		}
+		// Fallback for group folders and other global mounts that are not tracked
+		// in the user mount cache.
+		$nodes = $this->rootFolder->getById($fileId);
+		if (!empty($nodes)) {
+			return $nodes[0];
+		}
 		throw new NotFoundException();
 	}
 


### PR DESCRIPTION
Group folders use global/shared mounts that are not stored in the `IUserMountCache`**, which only tracks per-user home directory mounts. Because `getMountsForFileId` returns an empty array for group folder files, the loop body never executes and `NotFoundException` is thrown immediately.

The fix adds a fallback to `IRootFolder::getById()` after the user-mount-cache loop fails. `IRootFolder` has visibility into all storages — including group folder storages — and will resolve the file correctly even when `IUserMountCache` has no entries for it.

**Why group folders don't appear in `IUserMountCache`:** The user mount cache is populated when a user logs in and their personal mounts are registered. Group folder mounts are registered as global (app-level) mounts by the `groupfolders` app and are not per-user cache entries, so `getMountsForFileId` returns nothing for them.